### PR TITLE
Add catch and test for an empty array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "competency-acl",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "competency-acl",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^28.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "competency-acl",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -125,7 +125,10 @@ describe("Validate Arrays of Acls", () => {
             competencyAcl.behavior.updateDraft
         ];
         expect(validateAclArray(duplicates).sort()).toEqual(correct.sort());
-    })
+    });
+    it("Should return an empty array given an empty array", () => {
+        expect(validateAclArray([])).toEqual([]);
+    });
 });
 
 describe("Condense an Array of Acls", () => {

--- a/src/validateAcl.ts
+++ b/src/validateAcl.ts
@@ -176,5 +176,5 @@ function validateCompetencyAcl(module: string, permission: string, fullAcl: stri
  * @returns An acl with potential duplicates removed
  */
 function removeDuplicateAcls(acl: string[]): string[] {
-    return Array.from(new Set(acl));
+    return acl.length !== 0 ? Array.from(new Set(acl)) : [];
 }


### PR DESCRIPTION
This PR fixes a crash that would occur when an empty array was given.