### PR TITLE
:sparkles: Add Changes Requested Status Permissions

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -32,6 +32,7 @@ export const competencyAcl = {
 		getPublished: `${SERVICES.competency}:${MODULES.competencies}:getPublished`,
 		getDeprecated: `${SERVICES.competency}:${MODULES.competencies}:getDeprecated`,
 		deleteDraft: `${SERVICES.competency}:${MODULES.competencies}:deleteDraft`,
+		getChangesRequested: `${SERVICES.competency}:${MODULES.competencies}:changesRequested`,
 		reviewSubmitted: `${SERVICES.competency}:${MODULES.competencies}:reviewSubmitted`,
 		create: `${SERVICES.competency}:${MODULES.competencies}:create`,
 		version: `${SERVICES.competency}:${MODULES.competencies}:version`,
@@ -40,21 +41,25 @@ export const competencyAcl = {
 		wildcard: `${SERVICES.competency}:${MODULES.activity}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.activity}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.activity}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.activity}:updateChangesRequested`
 	},
 	name: {
 		wildcard: `${SERVICES.competency}:${MODULES.name}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.name}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.name}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.name}:updateChangesRequested`
 	},
 	actor: {
 		wildcard: `${SERVICES.competency}:${MODULES.actor}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.actor}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.actor}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.actor}:updateChangesRequested`
 	},
 	condition: {
 		wildcard: `${SERVICES.competency}:${MODULES.condition}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.condition}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.condition}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.condition}:updateChangesRequested`
 	},
 	documentation: {
 		wildcard: `${SERVICES.competency}:${MODULES.documentation}:*`,
@@ -62,26 +67,31 @@ export const competencyAcl = {
 		uploadSubmitted: `${SERVICES.competency}:${MODULES.documentation}:uploadSubmitted`,
 		updateDraft: `${SERVICES.competency}:${MODULES.documentation}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.documentation}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.documentation}:updateChangesRequested`
 	},
 	behavior: {
 		wildcard: `${SERVICES.competency}:${MODULES.behavior}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.behavior}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.behavior}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.behavior}:updateChangesRequested`
 	},
 	degree: {
 		wildcard: `${SERVICES.competency}:${MODULES.degree}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.degree}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.degree}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.degree}:updateChangesRequested`
 	},
 	employability: {
 		wildcard: `${SERVICES.competency}:${MODULES.employability}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.employability}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.employability}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.employability}:updateChangesRequested`
 	},
 	notes: {
 		wildcard: `${SERVICES.competency}:${MODULES.notes}:*`,
 		updateDraft: `${SERVICES.competency}:${MODULES.notes}:updateDraft`,
 		updateSubmitted: `${SERVICES.competency}:${MODULES.notes}:updateSubmitted`,
+		updateChangesRequested: `${SERVICES.competency}:${MODULES.notes}:updateChangesRequested`
 	},
 	user: {
 		wildcard: `${SERVICES.competency}:${MODULES.user}:*`,
@@ -104,6 +114,7 @@ export const competencyAcl = {
 		submitted: `${SERVICES.competency}:${MODULES.search}:submitted`,
 		draft: `${SERVICES.competency}:${MODULES.search}:draft`,
 		deprecated: `${SERVICES.competency}:${MODULES.search}:deprecated`,
+		changesRequested: `${SERVICES.competency}:${MODULES.search}:changesRequested`
 	},
 	lifecycle: {
 		wildcard: `${SERVICES.competency}:${MODULES.lifecycle}:wildcard`,
@@ -112,7 +123,9 @@ export const competencyAcl = {
 		cancelSubmission: `${SERVICES.competency}:${MODULES.lifecycle}:cancelSubmission`,
 		reject: `${SERVICES.competency}:${MODULES.lifecycle}:reject`,
 		approve: `${SERVICES.competency}:${MODULES.lifecycle}:approve`,
+		changesRequested: `${SERVICES.competency}:${MODULES.lifecycle}:changesRequested`,
 		reviseRejected: `${SERVICES.competency}:${MODULES.lifecycle}:reviseRejected`,
+		reviseChangesRequested: `${SERVICES.competency}:${MODULES.lifecycle}:reviseChangesRequested`
 	},
 };
 
@@ -135,6 +148,16 @@ export const basic_user_permissions = [
 	competencyAcl.search.wildcard,
 	competencyAcl.lifecycle.submit,
 	competencyAcl.lifecycle.cancelSubmission,
+	competencyAcl.lifecycle.reviseChangesRequested,
+	competencyAcl.lifecycle.changesRequested,
+	competencyAcl.activity.updateChangesRequested,
+	competencyAcl.name.updateChangesRequested,
+	competencyAcl.actor.updateChangesRequested,
+	competencyAcl.behavior.updateChangesRequested,
+	competencyAcl.condition.updateChangesRequested,
+	competencyAcl.degree.updateChangesRequested,
+	competencyAcl.documentation.updateChangesRequested,
+	competencyAcl.notes.updateChangesRequested
 ];
 
 export const ADMIN_VIEWER = [
@@ -142,6 +165,7 @@ export const ADMIN_VIEWER = [
 	competencyAcl.lifecycle.approve,
 	competencyAcl.lifecycle.reject,
 	competencyAcl.lifecycle.deprecate,
+	competencyAcl.lifecycle.reviseChangesRequested
 ];
 
 export const ADMIN_EDITOR = [
@@ -149,6 +173,7 @@ export const ADMIN_EDITOR = [
 	competencyAcl.lifecycle.approve,
 	competencyAcl.lifecycle.reject,
 	competencyAcl.lifecycle.deprecate,
+	competencyAcl.lifecycle.changesRequested,
 	competencyAcl.activity.updateSubmitted,
 	competencyAcl.name.updateSubmitted,
 	competencyAcl.actor.updateSubmitted,
@@ -159,5 +184,14 @@ export const ADMIN_EDITOR = [
 	competencyAcl.employability.updateSubmitted,
 	competencyAcl.notes.updateSubmitted,
 	competencyAcl.name.updateSubmitted,
-	competencyAcl.activity.updateSubmitted
+	competencyAcl.activity.updateSubmitted,
+	competencyAcl.user.getUsers,
+	competencyAcl.activity.updateChangesRequested,
+	competencyAcl.name.updateChangesRequested,
+	competencyAcl.actor.updateChangesRequested,
+	competencyAcl.behavior.updateChangesRequested,
+	competencyAcl.condition.updateChangesRequested,
+	competencyAcl.degree.updateChangesRequested,
+	competencyAcl.employability.updateChangesRequested,
+	competencyAcl.notes.updateChangesRequested
 ];

--- a/src/const.ts
+++ b/src/const.ts
@@ -32,7 +32,7 @@ export const competencyAcl = {
 		getPublished: `${SERVICES.competency}:${MODULES.competencies}:getPublished`,
 		getDeprecated: `${SERVICES.competency}:${MODULES.competencies}:getDeprecated`,
 		deleteDraft: `${SERVICES.competency}:${MODULES.competencies}:deleteDraft`,
-		getChangesRequested: `${SERVICES.competency}:${MODULES.competencies}:changesRequested`,
+		getChangesRequested: `${SERVICES.competency}:${MODULES.competencies}:getChangesRequested`,
 		reviewSubmitted: `${SERVICES.competency}:${MODULES.competencies}:reviewSubmitted`,
 		create: `${SERVICES.competency}:${MODULES.competencies}:create`,
 		version: `${SERVICES.competency}:${MODULES.competencies}:version`,

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -74,6 +74,7 @@ describe("Validate Valid Acls", () => {
 			new Set([
 				competencyAcl.actor.updateDraft,
 				competencyAcl.actor.updateSubmitted,
+				competencyAcl.actor.updateChangesRequested
 			])
 		);
 	});
@@ -82,6 +83,7 @@ describe("Validate Valid Acls", () => {
 			new Set([
 				competencyAcl.name.updateDraft,
 				competencyAcl.name.updateSubmitted,
+				competencyAcl.name.updateChangesRequested
 			])
 		);
 	});
@@ -130,8 +132,10 @@ describe("Validate Arrays of Acls", () => {
 				competencyGetWildcard.concat([
 					competencyAcl.actor.updateDraft,
 					competencyAcl.actor.updateSubmitted,
+					competencyAcl.actor.updateChangesRequested,
 					competencyAcl.name.updateDraft,
 					competencyAcl.name.updateSubmitted,
+					competencyAcl.name.updateChangesRequested,
 					competencyAcl.condition.updateDraft,
 					competencyAcl.search.rejected,
 				])

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -175,8 +175,10 @@ describe("Condense an Array of Acls", () => {
 			competencyAcl.apiKey.updateAcl,
 			competencyAcl.actor.updateDraft,
 			competencyAcl.actor.updateSubmitted,
+			competencyAcl.actor.updateChangesRequested,
 			competencyAcl.behavior.updateDraft,
 			competencyAcl.behavior.updateSubmitted,
+			competencyAcl.behavior.updateChangesRequested
 		];
 		correctArray = [
 			competencyAcl.apiKey.wildcard,

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -21,6 +21,7 @@ const competencyWildcard = [
 	competencyAcl.competencies.getDraft,
 	competencyAcl.competencies.version,
 	competencyAcl.competencies.reviewSubmitted,
+	competencyAcl.competencies.getChangesRequested,
 ];
 
 const competencyGetWildcard = [
@@ -29,6 +30,7 @@ const competencyGetWildcard = [
 	competencyAcl.competencies.getRejected,
 	competencyAcl.competencies.getSubmitted,
 	competencyAcl.competencies.getDraft,
+	competencyAcl.competencies.getChangesRequested
 ];
 
 describe("Validate Invalid Acls", () => {


### PR DESCRIPTION
Adds permissions for the new Changes Requested Status. 

Completes Story: https://app.shortcut.com/clarkcan/story/32618/update-competency-acl-for-changes-requested-status