### PR TITLE
Add lifecycle reviseRejected to basic user permissions

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -157,7 +157,8 @@ export const basic_user_permissions = [
 	competencyAcl.condition.updateChangesRequested,
 	competencyAcl.degree.updateChangesRequested,
 	competencyAcl.documentation.updateChangesRequested,
-	competencyAcl.notes.updateChangesRequested
+	competencyAcl.notes.updateChangesRequested,
+	competencyAcl.lifecycle.reviseRejected
 ];
 
 export const ADMIN_VIEWER = [

--- a/src/const.ts
+++ b/src/const.ts
@@ -158,7 +158,7 @@ export const basic_user_permissions = [
 	competencyAcl.degree.updateChangesRequested,
 	competencyAcl.documentation.updateChangesRequested,
 	competencyAcl.notes.updateChangesRequested,
-	competencyAcl.lifecycle.reviseRejected
+	competencyAcl.lifecycle.reviseDeclined
 ];
 
 export const ADMIN_VIEWER = [


### PR DESCRIPTION
This PR adds a missing permission to the basic user permissions that are assigned when a user signs up for the CC ecosystem. 