### PR TITLE
feat: [sc-36799] Update competency-acl to have new permissions for newly added 'Private' status.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "competency-acl",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "competency-acl",
-			"version": "0.10.0",
+			"version": "0.10.1",
 			"license": "ISC",
 			"devDependencies": {
 				"@types/jest": "^28.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "competency-acl",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "",
 	"main": "./lib/index.js",
 	"types": "./lib/index.d.ts",

--- a/src/const.ts
+++ b/src/const.ts
@@ -31,6 +31,7 @@ export const competencyAcl = {
 		getDeclined: `${SERVICES.competency}:${MODULES.competencies}:getDeclined`,
 		getPublished: `${SERVICES.competency}:${MODULES.competencies}:getPublished`,
 		getDeprecated: `${SERVICES.competency}:${MODULES.competencies}:getDeprecated`,
+		getPrivate:`${SERVICES.competency}:${MODULES.competencies}:getChangesRequested`,
 		deleteDraft: `${SERVICES.competency}:${MODULES.competencies}:deleteDraft`,
 		getChangesRequested: `${SERVICES.competency}:${MODULES.competencies}:getChangesRequested`,
 		reviewSubmitted: `${SERVICES.competency}:${MODULES.competencies}:reviewSubmitted`,
@@ -114,7 +115,8 @@ export const competencyAcl = {
 		submitted: `${SERVICES.competency}:${MODULES.search}:submitted`,
 		draft: `${SERVICES.competency}:${MODULES.search}:draft`,
 		deprecated: `${SERVICES.competency}:${MODULES.search}:deprecated`,
-		changesRequested: `${SERVICES.competency}:${MODULES.search}:changesRequested`
+		changesRequested: `${SERVICES.competency}:${MODULES.search}:changesRequested`,
+		private: `${SERVICES.competency}:${MODULES.search}:private`
 	},
 	lifecycle: {
 		wildcard: `${SERVICES.competency}:${MODULES.lifecycle}:wildcard`,
@@ -125,7 +127,8 @@ export const competencyAcl = {
 		approve: `${SERVICES.competency}:${MODULES.lifecycle}:approve`,
 		changesRequested: `${SERVICES.competency}:${MODULES.lifecycle}:changesRequested`,
 		reviseDeclined: `${SERVICES.competency}:${MODULES.lifecycle}:reviseDeclined`,
-		reviseChangesRequested: `${SERVICES.competency}:${MODULES.lifecycle}:reviseChangesRequested`
+		reviseChangesRequested: `${SERVICES.competency}:${MODULES.lifecycle}:reviseChangesRequested`,
+		privatize: `${SERVICES.competency}:${MODULES.lifecycle}:privatize`
 	},
 };
 
@@ -163,6 +166,7 @@ export const basic_user_permissions = [
 
 export const ADMIN_VIEWER = [
 	competencyAcl.competencies.reviewSubmitted,
+	competencyAcl.competencies.getPrivate,
 	competencyAcl.lifecycle.approve,
 	competencyAcl.lifecycle.decline,
 	competencyAcl.lifecycle.deprecate,
@@ -171,10 +175,12 @@ export const ADMIN_VIEWER = [
 
 export const ADMIN_EDITOR = [
 	competencyAcl.competencies.reviewSubmitted,
+	competencyAcl.competencies.getPrivate,
 	competencyAcl.lifecycle.approve,
 	competencyAcl.lifecycle.decline,
 	competencyAcl.lifecycle.deprecate,
 	competencyAcl.lifecycle.changesRequested,
+	competencyAcl.lifecycle.privatize,
 	competencyAcl.activity.updateSubmitted,
 	competencyAcl.name.updateSubmitted,
 	competencyAcl.actor.updateSubmitted,


### PR DESCRIPTION
Story details: https://app.shortcut.com/clarkcan/story/36799

Added getPrivate to Competencies module, private to the Search module, and privatize to the Lifecycles module. getPrivate gets added to all users on Basic User Permissions. The search private is added to Basic User Permissions as a default from the wildcard, then is added to both the Admin Viewer and Admin Editor permissions. The lifecyles private permission is only given to Admin Editors to be able to change a competency to become private. 